### PR TITLE
added the mixin "font-size" as a dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "tests"
   ],
   "dependencies": {
-    "spacelab-settings.defaults": "spacelab/settings.defaults"
+    "spacelab-settings.defaults": "spacelab/settings.defaults",
+    "spacelab-mixins.font-size": "spacelab/mixins.font-size"
   }
 }


### PR DESCRIPTION
Hi Spacelab team,

I added the mixin "font-size" as a dependency to bower.json, since it is being used inside of _base.paragraphs.scss. Is that okay with you?

Regards,
The Documentator
